### PR TITLE
fix: remove trailing slash from base config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,7 +1,7 @@
 site:
   name: 'Women Techmakers Madrid'
   site: 'https://wtmgdgmadrid.github.io/'
-  base: '/wtm-madrid-landing/' # Change this if you need to deploy to Github Pages, for example
+  base: '/wtm-madrid-landing' # Change this if you need to deploy to Github Pages, for example
   trailingSlash: false # Generate permalinks with or without "/" at the end
 
   googleSiteVerificationId: false # Or some value,


### PR DESCRIPTION
<img width="1309" height="296" alt="Captura de pantalla 2025-08-29 a la(s) 12 55 42 p  m" src="https://github.com/user-attachments/assets/922289dd-2935-41cf-a977-b4e4dc4d67bb" />



Modify the config.yaml file where trailingSlash changes it to false. What happens is that it overwrites the astro.config.ts file. In the future, we should keep that file and delete or disable the config.yaml file.